### PR TITLE
Changing PIL import to fix Image error

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -2,7 +2,7 @@ import numpy
 import scipy.io.wavfile
 import scipy.signal
 import sys
-import PIL
+import PIL.Image
 
 
 class APT(object):


### PR DESCRIPTION
apt.py is showing this error
 ```
jd@Juans-MacBook-Pro apt-decoder % python3 apt.py rs.wav rs1.pmng
Traceback (most recent call last):
  File "apt.py", line 100, in <module>
    apt.decode(outfile)
  File "apt.py", line 32, in decode
    image = PIL.Image.fromarray(matrix)
  File "/Library/Python/3.7/site-packages/PIL/__init__.py", line 42, in __getattr__
    raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
AttributeError: module 'PIL' has no attribute 'Image'
```
To fix this, is recommended to import **Image**
```
import PIL.Image
```
This fix the error and the image can be properly generated